### PR TITLE
Fix explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ table {
             </tr>
         </table>
         <h3>Raad alle QUADOORDLE woorden in 9 beurten.</h3>
-        <p>Elke gok moet een valide 5 letter woord zijn. Klik op enter als je klaar bent.<br><br>Na elke gok, veranderd de kleur van de kaart hoe goed de gok was.</p>
+        <p>Elke gok moet een betstaand 5 letter woord zijn. Klik op enter als je klaar bent.<br><br>Na elke gok zullen de kleuren van de vakjes aangeven hoe dichtbij je was.</p>
         <h2>Voorbeelden in het Engels</h2>
         <table style="width: 50%; border-spacing:0px;font-size:200%;">
             <tr>


### PR DESCRIPTION
Makes it more similar to the explanation at [woordle.nl](woordle.nl).

Initially, I came here to fix "veranderd" to "verandert", but the entire sentence isn't really proper Dutch :upside_down_face: I do like explanation of woordle.nl though, so here's a PR with this suggestion :smile: 